### PR TITLE
Pypi requires context-type of README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup()
+# read the contents of your README file
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
+setup(
+    name="climakitaegui",
+    # other arguments omitted
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+)


### PR DESCRIPTION
# Description of PR

Inform build process of the context type of README file for Pypi. When attempting to build got this error:

`The description failed to render in the default format of reStructuredText.`

Pypi now requires that `content-type` be set on the README uploaded:

https://github.com/pypi/warehouse/issues/5890

**Summary of changes and related issue**

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

