### PR TITLE
Fix WarmingLevelVisualize GCM stats and main rendering issues

### DIFF
--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -778,7 +778,7 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
                 )
 
                 # Create panel object: combine plot with shared colorbar
-                wl_plots = pn.Row(wl_plots)
+                wl_plots = pn.Row(wl_plots + shared_colorbar)
 
             warm_level_dict[warmlevel] = wl_plots
 

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -419,17 +419,19 @@ class WarmingLevelVisualize(param.Parameterized):
                     .dropna()
                     .index[0]
                 )
+                opts.defaults(opts.Curve(color=ssp_color, line_dash="dashed", line_width=1))
                 ssp_int = hv.Curve(
                     [[year_warmlevel_reached, -2], [year_warmlevel_reached, 10]],
                     label=label1,
-                ).opts(color=ssp_color, line_dash="dashed", line_width=1)
+                )
+                opts.defaults(opts.Text(style=dict(text_font_size="8pt", color=ssp_color)))
                 ssp_int = ssp_int * hv.Text(
                     x=year_warmlevel_reached - 2,
                     y=4.5,
                     text=str(int(year_warmlevel_reached)),
                     rotation=90,
                     label=label1,
-                ).opts(style=dict(text_font_size="8pt", color=ssp_color))
+                )
                 to_plot *= ssp_int  # Add to plot
 
             if (np.argmax(ssp_selected["95%"] > self.warmlevel)) > 0 and (
@@ -437,16 +439,14 @@ class WarmingLevelVisualize(param.Parameterized):
             ) > 0:
                 # Make 95% CI line
                 x_95 = cmip_t[0] + np.argmax(ssp_selected["95%"] > self.warmlevel)
-                ssp_firstdate = hv.Curve([[x_95, -2], [x_95, 10]], label=ci_label).opts(
-                    color=ssp_color, line_width=1
-                )
+                opts.defaults(opts.Curve(color=ssp_color, line_width=1))
+                ssp_firstdate = hv.Curve([[x_95, -2], [x_95, 10]], label=ci_label)
                 to_plot *= ssp_firstdate
 
                 # Make 5% CI line
                 x_5 = cmip_t[0] + np.argmax(ssp_selected["5%"] > self.warmlevel)
-                ssp_lastdate = hv.Curve([[x_5, -2], [x_5, 10]], label=ci_label).opts(
-                    color=ssp_color, line_width=1
-                )
+                opts.default(opts.Curve(color=ssp_color, line_width=1))
+                ssp_lastdate = hv.Curve([[x_5, -2], [x_5, 10]], label=ci_label)
                 to_plot *= ssp_lastdate
 
                 ## Bar to connect firstdate and lastdate of threshold cross
@@ -456,15 +456,15 @@ class WarmingLevelVisualize(param.Parameterized):
                     ssp_selected["95%"] > self.warmlevel
                 )
                 if yr_rng > 0:
+                    opts.default(opts.Curve(color=ssp_color, line_width=1))
+                    opts.default(opts.Text(style=dict(text_font_size="8pt", color=ssp_color)))
                     interval = hv.Curve(
                         [[x_95, bar_y], [x_5, bar_y]], label=ci_label
-                    ).opts(color=ssp_color, line_width=1) * hv.Text(
+                    ) * hv.Text(
                         x=x_95 + 5,
                         y=bar_y + 0.25,
                         text=str(yr_rng) + "yrs",
                         label=ci_label,
-                    ).opts(
-                        style=dict(text_font_size="8pt", color=ssp_color)
                     )
 
                     to_plot *= interval

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -655,7 +655,6 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
     Compute helper for stats postage stamps.
     Returns dictionary of warming levels to stats visuals.
     """
-    import pdb; pdb.set_trace()
     # Get data to plot
     warm_level_dict = {}
     for warmlevel in wl_viz.warming_levels:
@@ -683,9 +682,11 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
                 """
                 Returns the simulation closest to the median.
                 """
-                return data.loc[
-                    data == data.quantile(0.5, "all_sims", method="nearest")
-                ].all_sims.values.item()
+                return str(
+                    data.loc[
+                        data == data.quantile(0.5, "all_sims", method="nearest")
+                    ].all_sims.values[0]
+                )
 
             def find_sim(all_plot_data, area_avgs, stat_funcs, my_func):
                 if my_func == "Median":

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -869,7 +869,7 @@ def warming_levels_visualize(wl_viz):
         ),
         title="Regional response at selected warming level",
         width=850,
-        height=600,
+        height=800,
         collapsible=False,
         styles={
             "header_background": "lightgrey",

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -606,7 +606,7 @@ def GCM_PostageStamps_MAIN_compute(wl_viz):
                 )
 
                 # Create panel object: combine plot with shared colorbar
-                wl_plots = pn.Row(wl_plots)
+                wl_plots = pn.Row(wl_plots + shared_colorbar)
 
             # Add to dictionary
             warm_level_dict[warmlevel] = wl_plots

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -424,14 +424,13 @@ class WarmingLevelVisualize(param.Parameterized):
                     [[year_warmlevel_reached, -2], [year_warmlevel_reached, 10]],
                     label=label1,
                 )
-                opts.defaults(opts.Text(style=dict(text_font_size="8pt", color=ssp_color)))
                 ssp_int = ssp_int * hv.Text(
                     x=year_warmlevel_reached - 2,
                     y=4.5,
                     text=str(int(year_warmlevel_reached)),
                     rotation=90,
                     label=label1,
-                )
+                ).opts(opts.Text(font_size=8, color=ssp_color))
                 to_plot *= ssp_int  # Add to plot
 
             if (np.argmax(ssp_selected["95%"] > self.warmlevel)) > 0 and (

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -864,6 +864,7 @@ def warming_levels_visualize(wl_viz):
                 "Maps of cross-model statistics: median/max/min",
                 postage_stamps_STATS,
             ),
+            dynamic=True,
         ),
         title="Regional response at selected warming level",
         width=850,

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -655,6 +655,7 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
     Compute helper for stats postage stamps.
     Returns dictionary of warming levels to stats visuals.
     """
+    import pdb; pdb.set_trace()
     # Get data to plot
     warm_level_dict = {}
     for warmlevel in wl_viz.warming_levels:

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -29,7 +29,9 @@ from climakitaegui.core.data_interface import (
     _selections_param_to_panel,
 )
 from climakitaegui.core.data_view import compute_vmin_vmax
+
 hv.extension("bokeh")
+
 
 class WarmingLevels(BaseWarmingLevels):
     def __init__(self, **params):
@@ -419,7 +421,9 @@ class WarmingLevelVisualize(param.Parameterized):
                     .dropna()
                     .index[0]
                 )
-                opts.defaults(opts.Curve(color=ssp_color, line_dash="dashed", line_width=1))
+                opts.defaults(
+                    opts.Curve(color=ssp_color, line_dash="dashed", line_width=1)
+                )
                 ssp_int = hv.Curve(
                     [[year_warmlevel_reached, -2], [year_warmlevel_reached, 10]],
                     label=label1,
@@ -456,7 +460,9 @@ class WarmingLevelVisualize(param.Parameterized):
                 )
                 if yr_rng > 0:
                     opts.default(opts.Curve(color=ssp_color, line_width=1))
-                    opts.default(opts.Text(style=dict(text_font_size="8pt", color=ssp_color)))
+                    opts.default(
+                        opts.Text(style=dict(text_font_size="8pt", color=ssp_color))
+                    )
                     interval = hv.Curve(
                         [[x_95, bar_y], [x_5, bar_y]], label=ci_label
                     ) * hv.Text(

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -430,7 +430,7 @@ class WarmingLevelVisualize(param.Parameterized):
                     text=str(int(year_warmlevel_reached)),
                     rotation=90,
                     label=label1,
-                ).opts(opts.Text(font_size=8, color=ssp_color))
+                ).opts(opts.Text(fontsize=8, color=ssp_color))
                 to_plot *= ssp_int  # Add to plot
 
             if (np.argmax(ssp_selected["95%"] > self.warmlevel)) > 0 and (

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -311,7 +311,7 @@ class WarmingLevelVisualize(param.Parameterized):
     def GCM_PostageStamps_STATS(self):
         return self.stats_stamps[str(float(self.warmlevel))]
 
-    @param.depends("warmlevel", "ssp", watch=False)
+    @param.depends("warmlevel", "ssp", watch=True)
     def GMT_context_plot(self):
         """Display GMT plot using package data that updates whenever the warming level or SSP is changed by the user."""
         ## Plot dimensions

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -421,13 +421,11 @@ class WarmingLevelVisualize(param.Parameterized):
                     .dropna()
                     .index[0]
                 )
-                opts.defaults(
-                    opts.Curve(color=ssp_color, line_dash="dashed", line_width=1)
-                )
+
                 ssp_int = hv.Curve(
                     [[year_warmlevel_reached, -2], [year_warmlevel_reached, 10]],
                     label=label1,
-                )
+                ).opts(opts.Curve(color=ssp_color, line_dash="dashed", line_width=1))
                 ssp_int = ssp_int * hv.Text(
                     x=year_warmlevel_reached - 2,
                     y=4.5,
@@ -442,14 +440,16 @@ class WarmingLevelVisualize(param.Parameterized):
             ) > 0:
                 # Make 95% CI line
                 x_95 = cmip_t[0] + np.argmax(ssp_selected["95%"] > self.warmlevel)
-                opts.defaults(opts.Curve(color=ssp_color, line_width=1))
-                ssp_firstdate = hv.Curve([[x_95, -2], [x_95, 10]], label=ci_label)
+                ssp_firstdate = hv.Curve([[x_95, -2], [x_95, 10]], label=ci_label).opts(
+                    opts.Curve(color=ssp_color, line_width=1)
+                )
                 to_plot *= ssp_firstdate
 
                 # Make 5% CI line
                 x_5 = cmip_t[0] + np.argmax(ssp_selected["5%"] > self.warmlevel)
-                opts.default(opts.Curve(color=ssp_color, line_width=1))
-                ssp_lastdate = hv.Curve([[x_5, -2], [x_5, 10]], label=ci_label)
+                ssp_lastdate = hv.Curve([[x_5, -2], [x_5, 10]], label=ci_label).opts(
+                    opts.Curve(color=ssp_color, line_width=1)
+                )
                 to_plot *= ssp_lastdate
 
                 ## Bar to connect firstdate and lastdate of threshold cross
@@ -459,17 +459,15 @@ class WarmingLevelVisualize(param.Parameterized):
                     ssp_selected["95%"] > self.warmlevel
                 )
                 if yr_rng > 0:
-                    opts.default(opts.Curve(color=ssp_color, line_width=1))
-                    opts.default(
-                        opts.Text(style=dict(text_font_size="8pt", color=ssp_color))
-                    )
                     interval = hv.Curve(
                         [[x_95, bar_y], [x_5, bar_y]], label=ci_label
-                    ) * hv.Text(
+                    ).opts(opts.Curve(color=ssp_color, line_width=1)) * hv.Text(
                         x=x_95 + 5,
                         y=bar_y + 0.25,
                         text=str(yr_rng) + "yrs",
                         label=ci_label,
+                    ).opts(
+                        opts.Text(fontsize=8, color=ssp_color)
                     )
 
                     to_plot *= interval

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -606,7 +606,7 @@ def GCM_PostageStamps_MAIN_compute(wl_viz):
                 )
 
                 # Create panel object: combine plot with shared colorbar
-                wl_plots = pn.Row(wl_plots, shared_colorbar, align="center")
+                wl_plots = pn.Row(wl_plots)
 
             # Add to dictionary
             warm_level_dict[warmlevel] = wl_plots
@@ -778,7 +778,7 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
                 )
 
                 # Create panel object: combine plot with shared colorbar
-                wl_plots = pn.Row(wl_plots, shared_colorbar, align="center")
+                wl_plots = pn.Row(wl_plots)
 
             warm_level_dict[warmlevel] = wl_plots
 

--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -6,6 +6,7 @@ import hvplot.xarray
 import hvplot.pandas
 import holoviews as hv
 from holoviews import opts
+import holoviews.plotting.bokeh
 import matplotlib.pyplot as plt
 from scipy.stats import pearson3
 from climakitae.core.data_interface import DataInterface
@@ -28,7 +29,7 @@ from climakitaegui.core.data_interface import (
     _selections_param_to_panel,
 )
 from climakitaegui.core.data_view import compute_vmin_vmax
-
+hv.extension("bokeh")
 
 class WarmingLevels(BaseWarmingLevels):
     def __init__(self, **params):


### PR DESCRIPTION
# Description of PR

This PR fixes broken bokeh QuadMesh plots in WarmingLevelVisualize panel. It uses the `dynamic` option on `pn.Tabs` to render the plots dynamically. Seems there is an issue with retrieving rendered plots inside a dictionary and the panel Tabs. It also adds the shared colorbar to the plots instead of having it as a separate plot added in a separate column in panel (this caused spacing issues in the panel).

Also fixes #24 and the non-functional GMT Context plot. Plots in both panels now update when SSP and warming levels are changed.

**Summary of changes and related issue**

Changes how plots are rendered in panel Tabs.

**Relevant motivation and context**

Fixes last bug from switch Pangeo NB base.

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run through the Warming Levels notebook to visualize.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

