### PR TITLE
Move Pangeo Image to 2025.06.02

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 https://github.com/cal-adapt/climakitae/archive/main.zip #climakitae
 geoviews==1.14.0
-holoviews==1.20.0
-hvplot==0.11.2
+holoviews==1.20.2
+hvplot==0.11.3
 ipython==8.17.2
-matplotlib==3.10.0
-panel==1.5.5
+matplotlib==3.10.3
+panel==1.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     hvplot
     ipython<=8.17.2
     matplotlib
-    panel<=1.5.5
+    panel<=1.7.1
 tests_require =
     pytest
 


### PR DESCRIPTION
# Description of PR

Move package dependencies to match Pangeo 2025.06.02 image and keep synced with `climakitae` repo.

**Summary of changes and related issue**

`climakitae` package moving to Pangeo 2025.06.02 plus bumped packages for security patches.

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

Either load pangeo 2025.06.02 docker image and update packages with list above.

or create python 3.12.10 virtual environment and load the requirements.txt

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

