### PR TITLE
Update imported variables with correct names

### DIFF
--- a/climakitaegui/explore/warming.py
+++ b/climakitaegui/explore/warming.py
@@ -12,12 +12,12 @@ from scipy.stats import pearson3
 from climakitae.core.data_interface import DataInterface
 from climakitae.core.data_load import load
 from climakitae.core.paths import (
-    ssp119_file,
-    ssp126_file,
-    ssp245_file,
-    ssp370_file,
-    ssp585_file,
-    hist_file,
+    SSP119_FILE,
+    SSP126_FILE,
+    SSP245_FILE,
+    SSP370_FILE,
+    SSP585_FILE,
+    HIST_FILE,
 )
 from climakitae.explore.threshold_tools import _get_distr_func, _get_fitted_distr
 from climakitae.explore.warming import WarmingLevels as BaseWarmingLevels
@@ -255,12 +255,12 @@ class WarmingLevelVisualize(param.Parameterized):
     ## Produces dynamically updating gwl snapshot maps.
 
     # Read in GMT context plot data
-    ssp119_data = read_csv_file(ssp119_file, index_col="Year")
-    ssp126_data = read_csv_file(ssp126_file, index_col="Year")
-    ssp245_data = read_csv_file(ssp245_file, index_col="Year")
-    ssp370_data = read_csv_file(ssp370_file, index_col="Year")
-    ssp585_data = read_csv_file(ssp585_file, index_col="Year")
-    hist_data = read_csv_file(hist_file, index_col="Year")
+    ssp119_data = read_csv_file(SSP119_FILE, index_col="Year")
+    ssp126_data = read_csv_file(SSP126_FILE, index_col="Year")
+    ssp245_data = read_csv_file(SSP245_FILE, index_col="Year")
+    ssp370_data = read_csv_file(SSP370_FILE, index_col="Year")
+    ssp585_data = read_csv_file(SSP585_FILE, index_col="Year")
+    hist_data = read_csv_file(HIST_FILE, index_col="Year")
 
     warmlevel = param.Selector(
         default=1.5, objects=[1.5, 2, 3, 4], doc="Warming level in degrees Celcius."


### PR DESCRIPTION
# Description of PR

Updated imported variables in `warming.py` with the correct names

Imports were broken when merging `new-core-base` in `climakitae`

No new dependencies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open a python terminal:
```bash
python
```
now try to import warming levels:
```python
from climakitaegui.explore.warming import WarmingLevels
```
make sure it imports correctly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

